### PR TITLE
Fixing get_status to always refresh status.

### DIFF
--- a/nest_thermostat/__init__.py
+++ b/nest_thermostat/__init__.py
@@ -52,7 +52,7 @@ class Nest:
           self.device_id = res["structure"][self.structure_id]["devices"][self.index]
           self.serial = self.device_id.split(".")[1]
 
-          self.status = res
+       self.status = res
 
         #print "res.keys", res.keys()
         #print "res[structure][structure_id].keys", res["structure"][self.structure_id].keys()


### PR DESCRIPTION
`get_status` was not updating `status` after the initial call. After this pull request, every `get_status` call refreshes the status. 
